### PR TITLE
Update kube, kube-runtime, and k8s-openapi. Release version 0.2.0 due to compat change

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,10 +23,9 @@ jobs:
       with:
         command: clippy
         args: -- --deny warnings
-    - uses: actions-rs/cargo@v1
+    - uses: EmbarkStudios/cargo-deny-action@v1
       with:
-        command: deny
-        args: check
+        command: check
   test:
     runs-on: ubuntu-20.04
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.2.0] - 2023-08-09
+
+### Changed
+
+* Upgrade `kube` and `kube-runtime` to `0.85`
+    * This includes an interface change that replaces `ListParams` with `watcher::Config`, described here: https://github.com/MaterializeInc/kube-rs/blob/master/CHANGELOG.md#listwatch-changes
+    * The `namespaced`, `namespaced_all`, and `cluster` methods have been updated correspondingly; this will require an update if you are using them.
+* Upgrade `k8s-openapi` to `0.19` with `v1_25` enabled 
+
 ## [0.1.1] - 2023-07-14
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k8s-controller"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 description = "lightweight framework for writing kubernetes controllers"
@@ -12,9 +12,9 @@ include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 [dependencies]
 async-trait = "0.1.71"
 futures = "0.3.28"
-k8s-openapi = { version = "0.16", features = ["v1_24"] }
-kube = "0.77"
-kube-runtime = "0.77"
+k8s-openapi = { version = "0.19", features = ["v1_25"] }
+kube = "0.85"
+kube-runtime = "0.85"
 rand = "0.8.5"
 serde = "1.0.167"
 tracing = "0.1.37"

--- a/deny.toml
+++ b/deny.toml
@@ -13,6 +13,12 @@ multiple-versions = "deny"
 skip = [
     { name = "syn", version = "1.0.109" },
     { name = "syn", version = "2.0.23" },
+    { name = "bitflags", version = "1.3.2" },
+    { name = "bitflags", version = "2.3.3" },
+    { name = "base64", version = "0.13.1" },
+    { name = "base64", version = "0.20.0" },
+    { name = "base64", version = "0.21.2" },
+    { name = "socket2", version = "0.4.9" },
 ]
 
 # Use `tracing` instead.

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -5,11 +5,12 @@ use std::time::Duration;
 
 use futures::future::FutureExt;
 use futures::stream::StreamExt;
-use kube::api::{Api, ListParams};
+use kube::api::Api;
 use kube::core::{ClusterResourceScope, NamespaceResourceScope};
 use kube::{Client, Resource, ResourceExt};
 use kube_runtime::controller::Action;
 use kube_runtime::finalizer::{finalizer, Event};
+use kube_runtime::watcher;
 use rand::{thread_rng, Rng};
 use tracing::{event, Level};
 
@@ -45,10 +46,10 @@ where
     /// `client`. The `context` given determines the type of resource
     /// to watch (via the [`Context::Resource`] type provided as part of
     /// the trait implementation). The resources to be watched will be
-    /// limited to resources in the given `namespace`. A [`ListParams`]
+    /// limited to resources in the given `namespace`. A [`watcher::Config`]
     /// can be given to limit the resources watched (for instance,
-    /// `ListParams::default().labels("app=myapp")`).
-    pub fn namespaced(client: Client, context: Ctx, namespace: &str, lp: ListParams) -> Self
+    /// `watcher::Config::default().labels("app=myapp")`).
+    pub fn namespaced(client: Client, context: Ctx, namespace: &str, wc: watcher::Config) -> Self
     where
         Ctx::Resource: Resource<Scope = NamespaceResourceScope>,
     {
@@ -60,7 +61,7 @@ where
         };
         let controller = kube_runtime::controller::Controller::new(
             Api::<Ctx::Resource>::namespaced(client.clone(), namespace),
-            lp,
+            wc,
         );
         Self {
             client,
@@ -74,10 +75,10 @@ where
     /// `client`. The `context` given determines the type of resource to
     /// watch (via the [`Context::Resource`] type provided as part of the
     /// trait implementation). The resources to be watched will not be
-    /// limited by namespace. A [`ListParams`] can be given to limit the
+    /// limited by namespace. A [`watcher::Config`] can be given to limit the
     /// resources watched (for instance,
-    /// `ListParams::default().labels("app=myapp")`).
-    pub fn namespaced_all(client: Client, context: Ctx, lp: ListParams) -> Self
+    /// `watcher::Config::default().labels("app=myapp")`).
+    pub fn namespaced_all(client: Client, context: Ctx, wc: watcher::Config) -> Self
     where
         Ctx::Resource: Resource<Scope = NamespaceResourceScope>,
     {
@@ -89,7 +90,7 @@ where
         };
         let controller = kube_runtime::controller::Controller::new(
             Api::<Ctx::Resource>::all(client.clone()),
-            lp,
+            wc,
         );
         Self {
             client,
@@ -102,10 +103,10 @@ where
     /// Creates a new controller for a cluster-scoped resource using the
     /// given `client`. The `context` given determines the type of resource
     /// to watch (via the [`Context::Resource`] type provided as part of the
-    /// trait implementation). A [`ListParams`] can be given to limit the
+    /// trait implementation). A [`watcher::Config`] can be given to limit the
     /// resources watched (for instance,
-    /// `ListParams::default().labels("app=myapp")`).
-    pub fn cluster(client: Client, context: Ctx, lp: ListParams) -> Self
+    /// `watcher::Config::default().labels("app=myapp")`).
+    pub fn cluster(client: Client, context: Ctx, wc: watcher::Config) -> Self
     where
         Ctx::Resource: Resource<Scope = ClusterResourceScope>,
     {
@@ -115,7 +116,7 @@ where
         };
         let controller = kube_runtime::controller::Controller::new(
             Api::<Ctx::Resource>::all(client.clone()),
-            lp,
+            wc,
         );
         Self {
             client,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,8 +123,8 @@
 //! # use std::time::Duration;
 //! # use k8s_openapi::api::core::v1::Pod;
 //! # use kube::{Config, Client};
-//! # use kube::api::ListParams;
 //! # use kube_runtime::controller::Action;
+//! # use kube_runtime::watcher;
 //! # use tokio::task;
 //! # #[derive(Default, Clone)]
 //! # struct PodCounter {
@@ -156,7 +156,7 @@
 //! let controller = k8s_controller::Controller::namespaced_all(
 //!     kube_client,
 //!     context.clone(),
-//!     ListParams::default(),
+//!     watcher::Config::default(),
 //! );
 //! task::spawn(controller.run());
 //!


### PR DESCRIPTION
Upgrade to kube packages corresponding with PR in MZ repo https://github.com/MaterializeInc/materialize/pull/21034 and soon to cloud repo.

This requires a compatibility break because of one upstream in `kube-rs` so I've bumped this package to version `0.2.0`.

Supersedes #7 #8 #6 