### PR TITLE
bump kube to 0.87.1 and k8s-openapi to 0.20.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 [dependencies]
 async-trait = "0.1.71"
 futures = "0.3.28"
-k8s-openapi = { version = "0.19", features = ["v1_25"] }
-kube = "0.85"
-kube-runtime = "0.85"
+k8s-openapi = { version = "0.20", features = ["v1_26"] }
+kube = { version = "0.87", default-features = false, features = ["client"] }
+kube-runtime = "0.87"
 rand = "0.8.5"
 serde = "1.0.167"
 tracing = "0.1.37"


### PR DESCRIPTION
bump kube to 0.87.1 and k8s-openapi to 0.20.0