### PR TITLE
allow for configurable max reconciliation concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.1] - 2024-02-29
+
+### Changed
+ * Allow for configurable max reconciliation concurrency.
+
+
 ## [0.2.0] - 2023-08-09
 
 ### Changed

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -62,6 +62,10 @@ where
         let controller = kube_runtime::controller::Controller::new(
             Api::<Ctx::Resource>::namespaced(client.clone(), namespace),
             wc,
+        )
+        .with_config(
+            kube_runtime::Config::default()
+                .concurrency(Ctx::MAX_CONCURRENT_RECILIATIONS.to_owned()),
         );
         Self {
             client,
@@ -91,6 +95,10 @@ where
         let controller = kube_runtime::controller::Controller::new(
             Api::<Ctx::Resource>::all(client.clone()),
             wc,
+        )
+        .with_config(
+            kube_runtime::Config::default()
+                .concurrency(Ctx::MAX_CONCURRENT_RECILIATIONS.to_owned()),
         );
         Self {
             client,
@@ -117,6 +125,10 @@ where
         let controller = kube_runtime::controller::Controller::new(
             Api::<Ctx::Resource>::all(client.clone()),
             wc,
+        )
+        .with_config(
+            kube_runtime::Config::default()
+                .concurrency(Ctx::MAX_CONCURRENT_RECILIATIONS.to_owned()),
         );
         Self {
             client,
@@ -208,6 +220,12 @@ pub trait Context {
     /// controllers - if multiple controllers with the same finalizer name
     /// run against the same resource, unexpected behavior can occur.
     const FINALIZER_NAME: &'static str;
+
+    /// Max objects to reconcile concurrently.
+    /// Set to 0 for unbound concurrency.
+    /// Regardless of this attribute a given object
+    /// will not be reconciled twice at the same time.
+    const MAX_CONCURRENT_RECILIATIONS: &'static u16 = &0u16;
 
     /// This method is called when a watched resource is created or updated.
     /// The [`Client`] used by the controller is passed in to allow making


### PR DESCRIPTION
## Problem
There are some cases when we don't want unbound concurrency when reconciling objects. This could be because we want to avoid external rate limits, intentionally serialize reconciliation, or to avoid some temporary resource limits.

## Solution
This allows us to add a new constant to tune this on the Context structs, which will default to 0, unbound, concurrency.