### PR TITLE
Bump k8s-openapi feature to v1_29, and standardize docsrs cfg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k8s-controller"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 
 description = "lightweight framework for writing kubernetes controllers"
@@ -12,7 +12,7 @@ include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 [dependencies]
 async-trait = "0.1"
 futures = "0.3"
-k8s-openapi = { version = "0.22", default-features = false, features = ["v1_28"] }
+k8s-openapi = { version = "0.22", default-features = false, features = ["v1_29"] }
 kube = { version = "0.92.1", default-features = false, features = ["client"] }
 kube-runtime = "0.92.1"
 rand = "0.8"
@@ -21,6 +21,3 @@ tracing = "0.1"
 
 [dev-dependencies]
 tokio = "1"
-
-[package.metadata.docs.rs]
-rustdoc-args = ["--cfg", "docs_rs"]

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -202,7 +202,7 @@ where
 
 /// The [`Context`] trait should be implemented in order to provide callbacks
 /// for events that happen to resources watched by a [`Controller`].
-#[cfg_attr(not(docs_rs), async_trait::async_trait)]
+#[cfg_attr(not(docsrs), async_trait::async_trait)]
 pub trait Context {
     /// The type of Kubernetes [resource](Resource) that will be watched by
     /// the [`Controller`] this context is passed to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
-#![cfg_attr(docs_rs, feature(async_fn_in_trait))]
+#![cfg_attr(docsrs, feature(async_fn_in_trait))]
 
 //! This crate implements a lightweight framework around
 //! [`kube_runtime::Controller`] which provides a simpler interface for common


### PR DESCRIPTION
* Bump k8s-openapi feature to v1_29.
* Use standardized `docsrs` cfg instead of our custom `docs_rs`. https://github.com/rust-lang/cargo/issues/13875