### PR TITLE
Move k8s-openapi to dev dependency

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,7 @@ on:
 
 env:
   DOCKER_BUILDKIT: 1
+  K8S_OPENAPI_ENABLED_VERSION: 1.29
 
 jobs:
   lint:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k8s-controller"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 
 description = "lightweight framework for writing kubernetes controllers"
@@ -12,7 +12,6 @@ include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 [dependencies]
 async-trait = "0.1"
 futures = "0.3"
-k8s-openapi = { version = "0.22", default-features = false, features = ["v1_29"] }
 kube = { version = "0.92.1", default-features = false, features = ["client"] }
 kube-runtime = "0.92.1"
 rand = "0.8"
@@ -20,4 +19,5 @@ serde = "1"
 tracing = "0.1"
 
 [dev-dependencies]
+k8s-openapi = { version = "0.22", default-features = false, features = ["v1_29"] }
 tokio = "1"


### PR DESCRIPTION
Move k8s-openapi to dev dependency, so we don't have to bump the feature every time we bump a binary crate using it. This will also allow other people to use it besides just us, without forcing them to upgrade kubernetes in lockstep with us.