### PR TITLE
ubuntu-24.04 github actions runners

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,28 +13,38 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.83.0
         components: rustfmt, clippy
     - uses: Swatinem/rust-cache@v2
     - uses: actions-rs/cargo@v1
       with:
+        toolchain: 1.83.0
         command: fmt
         args: -- --check
     - uses: actions-rs/cargo@v1
       with:
+        toolchain: 1.83.0
         command: clippy
         args: -- --deny warnings
-    - uses: EmbarkStudios/cargo-deny-action@v1
+    - uses: actions-rs/cargo@v1
       with:
-        command: check
+        toolchain: 1.83.0
+        command: install
+        args: --locked cargo-deny --version=0.16.2
+    - uses: actions-rs/cargo@v1
+      with:
+        toolchain: 1.83.0
+        command: deny
+        args: check
   test:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.83.0
     - uses: Swatinem/rust-cache@v2
     - uses: actions-rs/cargo@v1
       with:
+        toolchain: 1.83.0
         command: test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
@@ -28,7 +28,7 @@ jobs:
       with:
         command: check
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "k8s-controller"
 version = "0.4.0"
 edition = "2021"
+rust-version = "1.83.0"
 
 description = "lightweight framework for writing kubernetes controllers"
 repository = "https://github.com/MaterializeInc/k8s-controller"

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,4 @@
+[graph]
 targets = [
     { triple = "aarch64-apple-darwin" },
     { triple = "aarch64-unknown-linux-gnu" },
@@ -6,19 +7,26 @@ targets = [
 ]
 
 [advisories]
-vulnerability = "deny"
+version = 2
+ignore = [
+  # Dependency of kube < 0.96.0, so temporarily whitelisting it until we upgrade.
+  # This is just saying the "derivative" crate is unmaintained, but nothing is
+  # actively dangerous yet.
+  "RUSTSEC-2024-0388",
+  # Dependency of kube, and has no known version without it.
+  # This is just saying the "instant" crate is unmaintained, but nothing is
+  # actively dangerous yet.
+  "RUSTSEC-2024-0384",
+]
 
 [bans]
 multiple-versions = "deny"
 skip = [
-    { name = "syn", version = "1.0.109" },
-    { name = "syn", version = "2.0.23" },
-    { name = "bitflags", version = "1.3.2" },
-    { name = "bitflags", version = "2.3.3" },
-    { name = "base64", version = "0.13.1" },
-    { name = "base64", version = "0.20.0" },
     { name = "base64", version = "0.21.2" },
-    { name = "socket2", version = "0.4.9" },
+    { name = "hashbrown", version = "0.14.5" },
+    { name = "syn", version = "1.0.109" },
+    { name = "thiserror", version = "1.0.69" },
+    { name = "thiserror-impl", version = "1.0.69" },
 ]
 
 # Use `tracing` instead.
@@ -31,13 +39,13 @@ name = "env_logger"
 name = "rustls"
 
 [licenses]
+version = 2
 allow = [
     "Apache-2.0",
     "BSD-3-Clause",
     "MIT",
-    "Unicode-DFS-2016",
+    "Unicode-3.0",
 ]
-copyleft = "deny"
 
 [sources]
 unknown-git = "deny"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 #![warn(clippy::wildcard_in_or_patterns)]
 #![warn(clippy::crosspointer_transmute)]
 #![warn(clippy::excessive_precision)]
-#![warn(clippy::overflow_check_conditional)]
+#![warn(clippy::panicking_overflow_checks)]
 #![warn(clippy::as_conversions)]
 #![warn(clippy::match_overlapping_arm)]
 #![warn(clippy::zero_divided_by_zero)]


### PR DESCRIPTION
Update github actions runners to ubuntu-24.04, fix clippy and cargo deny stuff that has atrophied, and update rust.