### PR TITLE
Enable k8s-openapi/latest feature when generating docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k8s-controller"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 rust-version = "1.89.0"
 
@@ -13,6 +13,7 @@ include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 [dependencies]
 async-trait = "0.1"
 futures = "0.3"
+k8s-openapi = { version = "0.26.0", default-features = false }
 kube = { version = "2.0.0", default-features = false, features = ["client"] }
 kube-runtime = "2.0.0"
 rand = "0.9.0"
@@ -22,3 +23,6 @@ tracing = "0.1"
 [dev-dependencies]
 k8s-openapi = { version = "0.26.0", default-features = false, features = ["v1_31"] }
 tokio = "1"
+
+[package.metadata.docs.rs]
+features = ["k8s-openapi/latest"]


### PR DESCRIPTION
The docs have been failing to build on docs.rs for a while now.